### PR TITLE
Add FormulaStyleConstraint to the auto-layout section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Swiftstraints](https://github.com/Skyvive/Swiftstraints) - Powerful auto-layout framework that lets you write constraints in one line of code.
 * [Tails](https://github.com/nickynick/Tails) - declarative autolayout for ios app written in swift.
 * [VFLToolbox](https://github.com/0xc010d/VFLToolbox) - fancy Swift implementation of the Visual Format Language
+* [FormulaStyleConstraint](https://github.com/fhisa/FormulaStyleConstraint) - Lightweight mathematical declarative auto-layout framework for Swift.
 
 ### Localization
 *Frameworks that helps with localizing your app*


### PR DESCRIPTION
added a self-made framework named FormulaStyleConstraint to the auto-layout section.

Use of the framework example:
```swift
baseView.addConstraints([
    mainView[.Top] == topLayoutGuide[.Bottom] + 8
    mainView[.Leading] == baseView[.Leading] + 8
    mainView[.Trailing] == baseView[.Trailing] + 8
    mainView[.Height] == (3.0 / 4.0) * baseView[.Height]
    subView[.Top] == mainView[.Bottom] + 8
    subView[.Leading] == baseView[.Leading] + 8
    subView[.Trailing] == baseView[.Trailing] + 8
    subView[.Bottom] == bottomLayoutGuide[.Top] - 8
    ])
```
